### PR TITLE
Git Authentication half-working

### DIFF
--- a/src/Chirp.Web/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -150,6 +150,7 @@ namespace Chirp.Web.Areas.Identity.Pages.Account
                 return RedirectToPage("./Login", new { ReturnUrl = returnUrl });
             }
 
+
             if (ModelState.IsValid)
             {
                 var user = CreateUser();
@@ -195,6 +196,13 @@ namespace Chirp.Web.Areas.Identity.Pages.Account
 
             ProviderDisplayName = info.ProviderDisplayName;
             ReturnUrl = returnUrl;
+            if (info.Principal.HasClaim(c => c.Type == ClaimTypes.Email))
+            {
+                Input = new InputModel
+                {
+                    Email = info.Principal.FindFirstValue(ClaimTypes.Email)
+                };
+            }
             return Page();
         }
 

--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.21" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.21" />
@@ -31,5 +32,15 @@
   <ItemGroup>
     <Folder Include="Areas\Identity\Data\" />
   </ItemGroup>
+
+   <PropertyGroup>
+      <TargetFramework>net8.0</TargetFramework>
+      <Nullable>enable</Nullable>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <RootNamespace>Chirp.Web</RootNamespace>
+
+      <!-- Add this -->
+      <UserSecretsId>chirp-web-dev</UserSecretsId>
+    </PropertyGroup>
 
 </Project>

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -3,6 +3,10 @@ using Chirp.Core;
 using Chirp.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using System.Security.Claims;
+using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -43,6 +47,24 @@ builder.Services.AddDefaultIdentity<Author>(options =>
 builder.Services.AddRazorPages();
 builder.Services.AddScoped<ICheepService, CheepService>();
 builder.Services.AddScoped<ICheepRepository, CheepRepository>();
+
+// github authentication
+builder.Services.AddAuthentication(options =>
+    {
+        options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = "GitHub";
+    })
+    .AddCookie()
+    .AddGitHub(o =>
+    {
+        o.ClientId = builder.Configuration["authentication:github:clientId"];
+        o.ClientSecret = builder.Configuration["authentication:github:clientSecret"];
+        o.CallbackPath = "/signin-github";
+        o.Scope.Add("user:email"); // Explicitly asking for Email as Github can be difficult to get Email from
+        o.SaveTokens = true; // maybe
+
+    });
 
 var app = builder.Build();
 

--- a/src/Chirp.Web/Properties/launchSettings.json
+++ b/src/Chirp.Web/Properties/launchSettings.json
@@ -8,21 +8,11 @@
     }
   },
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5273",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "CHIRPDBPATH": "../Chirp.SQLite/chirp.db"
-      }
-    },
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7102;http://localhost:5273",
+      "applicationUrl": "https://localhost:5273",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
GitAuth works to a point, but has trouble storing the data in the Database. 

Pulling this into main could potentially cause issues as the "http" profile has been deleted and replaced by "https" only. This is because we cannot do Git Authentication with http alone.
I have tested on my end, and encountered no problems with changing the profile to https.

Otherwise, pulling this into main should cause no issues, as the GitAuth code simply uses the scaffolded ExternalLogin page with no change.

Covers all success criteria of issue #110 - However, note that this issue lacks the success criteria for saving the login data to the database.