### PR TITLE
Add Env.IsProduction() to make subsequent pages on Chirp HTTPS.

### DIFF
--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -93,6 +93,10 @@ using (var scope = app.Services.CreateScope())
     //context.Database.Migrate();
 }
 
+if(app.Environment.IsProduction())
+{
+    app.UseHsts(); // Send HSTS headers, but only in production
+}
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();


### PR DESCRIPTION
The website is only HTTPS on the front page, this is to make the security global. This is a minor fix which closes #131 