### PR TITLE
Add the HSTS from the book in program

### DIFF
--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -55,7 +55,11 @@ builder.Services.AddScoped<ICheepService, CheepService>();
 builder.Services.AddScoped<ICheepRepository, CheepRepository>();
 builder.Services.AddScoped<IAuthorService, AuthorService>();
 builder.Services.AddScoped<IAuthorRepository, AuthorRepository>();
-
+// HSTS necessary for the HSTS header for reasons
+builder.Services.AddHsts(options =>
+{
+    options.MaxAge = TimeSpan.FromHours(1);
+});
 // github authentication
 builder.Services.AddAuthentication()
     /*


### PR DESCRIPTION
This pull request introduces an improvement to the web application’s security configuration by enabling HTTP Strict Transport Security (HSTS) in the `Program.cs` file. This ensures that browsers interact with the site only over HTTPS for a specified period.